### PR TITLE
Refactor text_to_speech to output bytes instead of saving directly to file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "cloai"
-version = "0.0.1a11"
+version = "0.0.1a12"
 description = "A CLI for OpenAI's API"
 authors = ["Reinder Vos de Wael <reinder.vosdewael@childmind.org>"]
 license = "LGPL-2.1"

--- a/src/cloai/cli/commands.py
+++ b/src/cloai/cli/commands.py
@@ -214,7 +214,8 @@ async def text_to_speech(
     """
     logger.debug("Converting text to speech.")
     tts = openai_api.TextToSpeech()
-    await tts.run(text, output_file, model=model, voice=voice)
+    audio_bytes = await tts.run(text, model=model, voice=voice)
+    await utils.save_file(output_file, audio_bytes)
 
 
 async def image_generation(  # noqa: PLR0913

--- a/src/cloai/core/utils.py
+++ b/src/cloai/core/utils.py
@@ -61,6 +61,17 @@ def clip_audio(
     yield from files
 
 
+async def save_file(filename: str | pathlib.Path, content: bytes) -> None:
+    """Saves content to a file asynchronously.
+
+    Args:
+        filename: The name of the file to save the content to.
+        content: The content to save to the file.
+    """
+    async with aiofiles.open(filename, "wb") as file:
+        await file.write(content)
+
+
 async def download_file(filename: str | pathlib.Path, url: str) -> None:
     """Downloads a file from a URL.
 

--- a/src/cloai/openai_api.py
+++ b/src/cloai/openai_api.py
@@ -81,10 +81,9 @@ class TextToSpeech(OpenAIBaseClass):
     async def run(
         self,
         text: str,
-        output_file: pathlib.Path | str,
         model: str = "tts-1",
         voice: Literal["alloy", "echo", "fable", "onyx", "nova", "shimmer"] = "onyx",
-    ) -> None:
+    ) -> bytes:
         """Runs the Text-To-Speech model.
 
         Args:
@@ -101,7 +100,7 @@ class TextToSpeech(OpenAIBaseClass):
             voice=voice,
             input=text,
         )
-        response.stream_to_file(output_file)
+        return response.content
 
 
 class SpeechToText(OpenAIBaseClass):

--- a/tests/unit/test_openai_api.py
+++ b/tests/unit/test_openai_api.py
@@ -31,7 +31,7 @@ async def test_text_to_speech(mock_openai: mock.AsyncMock) -> None:
     """Tests the TextToSpeech class."""
     text_to_speech = openai_api.TextToSpeech()
 
-    await text_to_speech.run("", output_file="")
+    await text_to_speech.run("")
 
     assert text_to_speech.client is not None
     assert mock_openai.call_count == 1


### PR DESCRIPTION
This pull request refactors the `text_to_speech` function to output audio bytes instead of saving the audio directly to a file. This change improves flexibility and allows for further processing of the audio data.